### PR TITLE
docs: add web app run instructions for Vite + Amplify v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ One major disclaimer at this time: This demo was built taking the path of least 
 
 Another goal in building this demo was to illustrate the use of AWS Amplify to build browser based web applications to integrate with AWS IoT Core using new enhanced custom authorizers. Example code can be found under the [web](./web) directory of this repository.
 
+## Running the Web Application
+
+The web application uses [Vite](https://vite.dev/) and [AWS Amplify v6](https://docs.amplify.aws/).
+
+```bash
+cd web
+npm install
+npm start
+```
+
+Before running, update the `mqtt_host` variable in `src/App.jsx` with your ATS-specific custom domain endpoint (from the `describe-domain-configuration` output above).
+
 ## MQTT/TLS username/password auth
 
 If you want to test the Custom Authorizer for MQTT/TLS connections using username and password authentication, please checkout the [mqtt-username-password](https://github.com/aws-samples/aws-iot-enhanced-custom-authorizer-demo/tree/mqtt-username-password) branch


### PR DESCRIPTION
Adds a short section to README with
  instructions for running the web app after the CRA → Vite migration.